### PR TITLE
new setting "Keep position within collections"

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -49,5 +49,6 @@ const
     ENABLE_ANDROID = 'enable_android',
     ENABLE_AUTOPLAY = 'enable_autoplay',
     ENABLE_LAST_OPEN = 'enable_last_open',
+    ENABLE_POSITIONS = 'enable_positions',
     SMALL_GRID = 'small_grid',
     HIDE_SUPPORT = 'hide_support'

--- a/layer_grid/GameGrid.qml
+++ b/layer_grid/GameGrid.qml
@@ -154,6 +154,8 @@ FocusScope {
                 }
             }
         }
+
+        Component.onCompleted: positionViewAtIndex(currentIndex, GridView.Contain)
     }
 
 

--- a/layer_theme_settings/ThemeSettingsPanel.qml
+++ b/layer_theme_settings/ThemeSettingsPanel.qml
@@ -48,7 +48,7 @@ FocusScope {
             value: api.memory.get(CONSTANTS.MAIN_COLOUR) || ''
             onValueChange: updateColour()
 
-            KeyNavigation.up: itemLastOpen
+            KeyNavigation.up: itemPositions
             KeyNavigation.down: itemFavorites
         }
 
@@ -133,8 +133,20 @@ FocusScope {
             onCheckedChange: updateLastOpen()
 
             KeyNavigation.up: itemHideSupport
-            KeyNavigation.down: itemColour
+            KeyNavigation.down: itemPositions
         }
+
+        CheckBox {
+            id: itemPositions
+            text: "Keep position within collections"
+            textColor: root.textColor
+            fontSize: content.normalTextSize
+            checked: api.memory.get(CONSTANTS.ENABLE_POSITIONS) || false
+            onCheckedChange: updatePositions()
+
+            KeyNavigation.up: itemLastOpen
+            KeyNavigation.down: itemColour
+        }        
     }
 
     function updateColour() {
@@ -164,5 +176,9 @@ FocusScope {
             api.memory.set('collection', '')
             api.memory.set('game', '')
         }
+    }
+    function updatePositions() {
+        api.memory.set(CONSTANTS.ENABLE_POSITIONS, itemPositions.checked);
+        if (!itemPositions.checked) clearPositions();
     }
 }

--- a/theme.qml
+++ b/theme.qml
@@ -64,12 +64,16 @@ FocusScope {
 
         if (api.keys.isPrevPage(event)) {
             event.accepted = true;
+            if (api.memory.get(CONSTANTS.ENABLE_POSITIONS)) savePosition();            
             topbar.prev();
+            if (api.memory.get(CONSTANTS.ENABLE_POSITIONS)) loadPosition();
             return;
         }
         if (api.keys.isNextPage(event)) {
             event.accepted = true;
+            if (api.memory.get(CONSTANTS.ENABLE_POSITIONS)) savePosition();            
             topbar.next();
+            if (api.memory.get(CONSTANTS.ENABLE_POSITIONS)) loadPosition();
             return;
         }
         if (api.keys.isDetails(event)) {
@@ -269,6 +273,7 @@ FocusScope {
         if (!api.memory.get(CONSTANTS.ENABLE_LAST_OPEN)) {
             topbar.currentIndex = 0;
             gamegrid.currentIndex = 0;
+            if (api.memory.get(CONSTANTS.ENABLE_POSITIONS)) loadPosition();
             gamegrid.memoryLoaded = true;
             return
         }
@@ -292,11 +297,40 @@ FocusScope {
             .games
             .toVarArray()
             .findIndex(g => g.title === last_game);
-        if (last_game_idx < 0)
+        if (last_game_idx < 0) {
+            if (api.memory.get(CONSTANTS.ENABLE_POSITIONS)) loadPosition();
             return;
+        }
 
         gamegrid.currentIndex = last_game_idx;
         gamegrid.memoryLoaded = true;
+    }
+
+    Component.onDestruction: {
+        if (api.memory.get(CONSTANTS.ENABLE_POSITIONS)) savePosition();
+    }
+
+    function clearPositions() {
+        for (var i = 0; i < allCollections.length; i++) {
+            api.memory.unset('collection' + i + 'GameIndex');
+        }
+    }
+
+    function clearPositionsIfNeeded() {
+        if ((api.memory.get('collectionCount') || 0) != allCollections.length) {
+            api.memory.set('collectionCount', allCollections.length);        
+            clearPositions();
+        }
+    }    
+
+    function savePosition() {
+        clearPositionsIfNeeded();
+        api.memory.set('collection' + topbar.currentIndex + 'GameIndex', gamegrid.currentIndex);
+    }
+
+    function loadPosition() {
+        clearPositionsIfNeeded();
+        gamegrid.currentIndex = api.memory.get('collection' + topbar.currentIndex + 'GameIndex') || 0;
     }
 
     function launchGame() {


### PR DESCRIPTION
Saves & restores last position within each collection. Positions clear when # of collections change or setting turned off. A specific position might become outdated if the number of entries in that collection changes, but I don't address this. Doesn't interfere with "Keep last open."

Also a line to ensure highlighted item is brought into view at launch.