### PR TITLE
Add disable guide option to settings

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -49,5 +49,6 @@ const
     ENABLE_ANDROID = 'enable_android',
     ENABLE_AUTOPLAY = 'enable_autoplay',
     ENABLE_LAST_OPEN = 'enable_last_open',
+    DISABLE_GUIDE = 'disable_guide',
     SMALL_GRID = 'small_grid',
     HIDE_SUPPORT = 'hide_support'

--- a/layer_theme_settings/ThemeSettingsPanel.qml
+++ b/layer_theme_settings/ThemeSettingsPanel.qml
@@ -48,7 +48,7 @@ FocusScope {
             value: api.memory.get(CONSTANTS.MAIN_COLOUR) || ''
             onValueChange: updateColour()
 
-            KeyNavigation.up: itemLastOpen
+            KeyNavigation.up: itemDisableGuide
             KeyNavigation.down: itemFavorites
         }
 
@@ -133,6 +133,18 @@ FocusScope {
             onCheckedChange: updateLastOpen()
 
             KeyNavigation.up: itemHideSupport
+            KeyNavigation.down: itemDisableGuide
+        }
+
+        CheckBox {
+            id: itemDisableGuide
+            text: "Disable guide"
+            textColor: root.textColor
+            fontSize: content.normalTextSize
+            checked: api.memory.get(CONSTANTS.DISABLE_GUIDE) || false
+            onCheckedChange: updateDisableGuide()
+
+            KeyNavigation.up: itemLastOpen
             KeyNavigation.down: itemColour
         }
     }
@@ -164,5 +176,8 @@ FocusScope {
             api.memory.set('collection', '')
             api.memory.set('game', '')
         }
+    }
+    function updateDisableGuide() {
+        api.memory.set(CONSTANTS.DISABLE_GUIDE, itemDisableGuide.checked)        
     }
 }

--- a/theme.qml
+++ b/theme.qml
@@ -97,7 +97,7 @@ FocusScope {
         }
 
         // Retroid Joystick
-        if(event.key == 0) {
+        if(event.key == 0 && !api.memory.get(CONSTANTS.DISABLE_GUIDE)) {
             event.accepted = true
             bottombar.toggleHelp()
             return;


### PR DESCRIPTION
Hello. Love your pegasus theme for Retroid. However, I decided to tweak it with a new option. I was often accidentally enabling the guide/help screen by moving analog stick and that was annoying. Added option to disable guide. If you find it useful then feel free to merge that to your master. Cheers!


By checking Disable guide option you cannot show guide/help widget
by clicking analog stick.